### PR TITLE
Add basic Flask server with clock-in API

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -1,0 +1,16 @@
+import os
+
+# Configuración del servidor
+HOST = '0.0.0.0'
+PORT = int(os.environ.get('PORT', 5000))
+DEBUG = os.environ.get('DEBUG', 'False').lower() == 'true'
+
+# Configuración de la base de datos MIE
+DB_SERVER = 'GUNDMAIN'
+DB_USER = 'mie'
+DB_PASSWORD = 'mie'
+DB_NAME = 'GunderlinLive'
+
+# Timeouts
+COMMAND_TIMEOUT = 30  # segundos
+VALIDATION_TIMEOUT = 10  # segundos

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,18 @@
+from flask import Flask
+from flask_cors import CORS
+from routes import api_bp
+import config
+
+app = Flask(__name__)
+CORS(app)
+
+# Registrar blueprints
+app.register_blueprint(api_bp, url_prefix='/api')
+
+if __name__ == '__main__':
+    print(f"🟢 Servidor iniciando en puerto {config.PORT}")
+    app.run(
+        host=config.HOST,
+        port=config.PORT,
+        debug=config.DEBUG
+    )

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,9 @@
+Flask==2.3.3
+Flask-CORS==4.0.0
+pymssql==2.2.8
+pyautogui==0.9.54
+pygetwindow==0.0.9
+Pillow==10.0.0
+numpy==1.24.3
+pyperclip==1.8.2
+keyboard==0.13.5

--- a/server/routes.py
+++ b/server/routes.py
@@ -1,0 +1,112 @@
+from flask import Blueprint, request, jsonify
+import uuid
+from datetime import datetime
+
+api_bp = Blueprint('api', __name__)
+
+# Para almacenar comandos en memoria (después será una queue)
+commands = {}
+
+@api_bp.route('/health', methods=['GET'])
+def health():
+    return jsonify({
+        'status': 'ok',
+        'timestamp': datetime.now().isoformat(),
+        'message': 'Servidor funcionando'
+    })
+
+@api_bp.route('/clockin-wo', methods=['POST'])
+def clockin_wo():
+    try:
+        data = request.json
+        
+        # Validar datos requeridos
+        required_fields = ['user_id', 'wo_number', 'operation', 'router_id']
+        for field in required_fields:
+            if field not in data:
+                return jsonify({
+                    'success': False,
+                    'error': f'Campo requerido: {field}'
+                }), 400
+        
+        # Generar ID único para el comando
+        command_id = str(uuid.uuid4())
+        
+        # Simular procesamiento (después será la queue)
+        commands[command_id] = {
+            'status': 'pending',
+            'type': 'clockin-wo',
+            'data': data,
+            'timestamp': datetime.now().isoformat(),
+            'message': 'Comando en cola'
+        }
+        
+        return jsonify({
+            'success': True,
+            'command_id': command_id,
+            'message': 'Clock In encolado correctamente'
+        })
+        
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500
+
+@api_bp.route('/clockout', methods=['POST'])
+def clockout():
+    try:
+        data = request.json
+        
+        # Validar datos requeridos
+        required_fields = ['user_id', 'wo_number']
+        for field in required_fields:
+            if field not in data:
+                return jsonify({
+                    'success': False,
+                    'error': f'Campo requerido: {field}'
+                }), 400
+        
+        # Generar ID único para el comando
+        command_id = str(uuid.uuid4())
+        
+        # Simular procesamiento (después será la queue)
+        commands[command_id] = {
+            'status': 'pending',
+            'type': 'clockout',
+            'data': data,
+            'timestamp': datetime.now().isoformat(),
+            'message': 'Comando en cola'
+        }
+        
+        return jsonify({
+            'success': True,
+            'command_id': command_id,
+            'message': 'Clock Out encolado correctamente'
+        })
+        
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500
+
+@api_bp.route('/status/<command_id>', methods=['GET'])
+def get_status(command_id):
+    if command_id not in commands:
+        return jsonify({
+            'success': False,
+            'error': 'Comando no encontrado'
+        }), 404
+    
+    return jsonify({
+        'success': True,
+        'command': commands[command_id]
+    })
+
+@api_bp.route('/commands', methods=['GET'])
+def list_commands():
+    return jsonify({
+        'success': True,
+        'commands': list(commands.values())
+    })


### PR DESCRIPTION
## Summary
- add Flask app wiring with CORS and configuration
- implement health check, clock-in/out, and command listing routes
- document dependencies in requirements file

## Testing
- `pip install -r server/requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*
- `pip install Flask==2.3.3 Flask-CORS==4.0.0`
- `python server/main.py`
- `curl -i http://localhost:5000/api/health`
- `curl -i -H "Content-Type: application/json" -d '{"user_id":"abc","wo_number":"WO2","operation":"OpB","router_id":"R2"}' http://localhost:5000/api/clockin-wo`
- `curl -i http://localhost:5000/api/commands`


------
https://chatgpt.com/codex/tasks/task_e_68a8609f744c83319ff3b928b50e8189