### PR TITLE
Implement command queue for clock in/out processing

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1,7 +1,9 @@
 from flask import Flask
 from flask_cors import CORS
 from routes import api_bp
+from queue_handler import command_queue
 import config
+import atexit
 
 app = Flask(__name__)
 CORS(app)
@@ -9,10 +11,27 @@ CORS(app)
 # Registrar blueprints
 app.register_blueprint(api_bp, url_prefix='/api')
 
+# Función para cleanup al cerrar
+def cleanup():
+    print("🛑 Cerrando servidor...")
+    command_queue.stop()
+
+# Registrar cleanup
+atexit.register(cleanup)
+
 if __name__ == '__main__':
     print(f"🟢 Servidor iniciando en puerto {config.PORT}")
-    app.run(
-        host=config.HOST,
-        port=config.PORT,
-        debug=config.DEBUG
-    )
+
+    # Iniciar queue handler
+    command_queue.start()
+
+    try:
+        app.run(
+            host=config.HOST,
+            port=config.PORT,
+            debug=config.DEBUG
+        )
+    except KeyboardInterrupt:
+        print("\n🛑 Servidor interrumpido")
+    finally:
+        cleanup()

--- a/server/queue_handler.py
+++ b/server/queue_handler.py
@@ -1,0 +1,141 @@
+import threading
+import time
+import uuid
+from datetime import datetime
+from queue import Queue
+from actions.clockin_wo import hacer_clockin_workorder
+from actions.clockout import hacer_clockout
+from logic.validation import (
+    validar_pre_clockin, validar_post_clockin,
+    validar_pre_clockout, validar_post_clockout
+)
+
+
+class CommandQueue:
+    def __init__(self):
+        self.queue = Queue()
+        self.commands = {}
+        self.worker_thread = None
+        self.running = False
+
+    def start(self):
+        """Iniciar el worker thread"""
+        if not self.running:
+            self.running = True
+            self.worker_thread = threading.Thread(target=self._worker, daemon=True)
+            self.worker_thread.start()
+            print("🟢 Queue handler iniciado")
+
+    def stop(self):
+        """Detener el worker thread"""
+        self.running = False
+        if self.worker_thread:
+            self.worker_thread.join()
+            print("🔴 Queue handler detenido")
+
+    def add_command(self, command_type, data):
+        """Agregar comando a la cola"""
+        command_id = str(uuid.uuid4())
+        command = {
+            'id': command_id,
+            'type': command_type,
+            'data': data,
+            'status': 'pending',
+            'message': 'Comando en cola',
+            'timestamp': datetime.now().isoformat(),
+            'result': None,
+        }
+        self.commands[command_id] = command
+        self.queue.put(command)
+        print(f"📥 Comando {command_type} encolado: {command_id}")
+        return command_id
+
+    def get_command_status(self, command_id):
+        """Obtener estado de un comando"""
+        return self.commands.get(command_id)
+
+    def get_all_commands(self):
+        """Obtener todos los comandos"""
+        return list(self.commands.values())
+
+    def _worker(self):
+        """Worker thread que procesa comandos"""
+        while self.running:
+            try:
+                command = self.queue.get(timeout=1)
+                self._process_command(command)
+                self.queue.task_done()
+            except Exception as e:
+                if self.running:
+                    print(f"❌ Error en worker: {e}")
+                time.sleep(0.1)
+
+    def _process_command(self, command):
+        """Procesar un comando individual"""
+        command_id = command['id']
+        command_type = command['type']
+        data = command['data']
+        try:
+            self._update_command(command_id, 'processing', 'Ejecutando comando...')
+            print(f"⚙️ Procesando {command_type}: {command_id}")
+
+            if command_type == 'clockin-wo':
+                result = self._process_clockin_wo(data)
+            elif command_type == 'clockout':
+                result = self._process_clockout(data)
+            else:
+                result = f"❌ Tipo de comando desconocido: {command_type}"
+
+            success = result.startswith("✅")
+            status = 'completed' if success else 'failed'
+            self._update_command(command_id, status, result)
+            print(f"{'✅' if success else '❌'} Comando {command_id}: {result}")
+        except Exception as e:
+            error_msg = f"❌ Error ejecutando comando: {str(e)}"
+            self._update_command(command_id, 'failed', error_msg)
+            print(f"❌ Error en comando {command_id}: {e}")
+
+    def _process_clockin_wo(self, data):
+        """Procesar comando de clock in work order"""
+        user_id = data['user_id']
+        wo_number = data['wo_number']
+        operation = data['operation']
+        router_id = data['router_id']
+
+        if validar_pre_clockin(user_id):
+            return "⚠️ Usuario ya tiene un clock in activo"
+        result = hacer_clockin_workorder(user_id, operation, router_id, wo_number)
+        if result.startswith("✅"):
+            time.sleep(2)
+            if validar_post_clockin(user_id, wo_number):
+                return f"✅ Clock In exitoso en WO {wo_number}"
+            return "❌ Clock In falló en validación post"
+        return result
+
+    def _process_clockout(self, data):
+        """Procesar comando de clock out"""
+        user_id = data['user_id']
+        wo_number = data['wo_number']
+        qty = data.get('qty', 1.0)
+
+        if not validar_pre_clockout(user_id, wo_number):
+            return "⚠️ Usuario no está clock in en este WO"
+        result = hacer_clockout(user_id, wo_number, qty)
+        if result.startswith("✅"):
+            time.sleep(2)
+            if validar_post_clockout(user_id, wo_number):
+                return f"✅ Clock Out exitoso en WO {wo_number}"
+            return "❌ Clock Out falló en validación post"
+        return result
+
+    def _update_command(self, command_id, status, message):
+        """Actualizar estado de un comando"""
+        if command_id in self.commands:
+            self.commands[command_id].update({
+                'status': status,
+                'message': message,
+                'timestamp': datetime.now().isoformat(),
+            })
+
+
+command_queue = CommandQueue()

--- a/server/routes.py
+++ b/server/routes.py
@@ -1,38 +1,39 @@
 from flask import Blueprint, request, jsonify
 from datetime import datetime
+from queue_handler import command_queue
 
 api_bp = Blueprint('api', __name__)
 
-commands = {}
 
 @api_bp.route('/health', methods=['GET'])
 def health():
     return jsonify({
         'status': 'ok',
         'timestamp': datetime.now().isoformat(),
-        'message': 'Servidor funcionando'
+        'message': 'Servidor funcionando',
+        'queue_running': command_queue.running
     })
+
 
 @api_bp.route('/clockin-wo', methods=['POST'])
 def clockin_wo():
     try:
         data = request.json
 
-        from actions.clockin_wo import hacer_clockin_workorder
+        required_fields = ['user_id', 'wo_number', 'operation', 'router_id']
+        for field in required_fields:
+            if field not in data:
+                return jsonify({
+                    'success': False,
+                    'error': f'Campo requerido: {field}'
+                }), 400
 
-        result = hacer_clockin_workorder(
-            data['user_id'],
-            data['operation'],
-            data['router_id'],
-            data['wo_number']
-        )
-
-        success = result.startswith("✅")
+        command_id = command_queue.add_command('clockin-wo', data)
 
         return jsonify({
-            'success': success,
-            'message': result,
-            'timestamp': datetime.now().isoformat()
+            'success': True,
+            'command_id': command_id,
+            'message': 'Clock In encolado correctamente'
         })
 
     except Exception as e:
@@ -40,28 +41,30 @@ def clockin_wo():
             'success': False,
             'error': str(e)
         }), 500
+
 
 @api_bp.route('/clockout', methods=['POST'])
 def clockout():
     try:
         data = request.json
 
-        from actions.clockout import hacer_clockout
+        required_fields = ['user_id', 'wo_number']
+        for field in required_fields:
+            if field not in data:
+                return jsonify({
+                    'success': False,
+                    'error': f'Campo requerido: {field}'
+                }), 400
 
-        qty = data.get('qty', 1.0)
+        if 'qty' not in data:
+            data['qty'] = 1.0
 
-        result = hacer_clockout(
-            data['user_id'],
-            data['wo_number'],
-            qty
-        )
-
-        success = result.startswith("✅")
+        command_id = command_queue.add_command('clockout', data)
 
         return jsonify({
-            'success': success,
-            'message': result,
-            'timestamp': datetime.now().isoformat()
+            'success': True,
+            'command_id': command_id,
+            'message': 'Clock Out encolado correctamente'
         })
 
     except Exception as e:
@@ -70,22 +73,38 @@ def clockout():
             'error': str(e)
         }), 500
 
+
 @api_bp.route('/status/<command_id>', methods=['GET'])
 def get_status(command_id):
-    if command_id not in commands:
+    command = command_queue.get_command_status(command_id)
+
+    if not command:
         return jsonify({
             'success': False,
             'error': 'Comando no encontrado'
         }), 404
-    
+
     return jsonify({
         'success': True,
-        'command': commands[command_id]
+        'command': command
     })
+
 
 @api_bp.route('/commands', methods=['GET'])
 def list_commands():
+    commands = command_queue.get_all_commands()
     return jsonify({
         'success': True,
-        'commands': list(commands.values())
+        'commands': commands,
+        'total': len(commands)
+    })
+
+
+@api_bp.route('/queue/status', methods=['GET'])
+def queue_status():
+    return jsonify({
+        'success': True,
+        'running': command_queue.running,
+        'pending_commands': command_queue.queue.qsize(),
+        'total_commands': len(command_queue.commands)
     })


### PR DESCRIPTION
## Summary
- add `CommandQueue` worker to process clock in/out commands sequentially
- integrate queue startup and shutdown into server lifecycle
- expose endpoints to enqueue commands and query their status

## Testing
- `python -m py_compile server/queue_handler.py server/main.py server/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8658ac98c833195956155456180d5